### PR TITLE
Explicitly add `operation.name` using transform processor

### DIFF
--- a/otel-agent-operator/datadog-agent.yaml
+++ b/otel-agent-operator/datadog-agent.yaml
@@ -77,6 +77,11 @@ spec:
               check_interval: 5s
               limit_percentage: 80
               spike_limit_percentage: 25
+            transform:
+              trace_statements:
+                - context: span
+                  statements:
+                    - set(attributes["operation.name"], name)
           connectors:
             datadog/connector:
               traces:
@@ -87,13 +92,13 @@ spec:
             pipelines:
               traces:
                 receivers: [otlp]
-                processors: [memory_limiter, infraattributes, batch]
+                processors: [memory_limiter, transform, infraattributes, batch]
                 exporters: [debug, datadog, datadog/connector]
               metrics:
                 receivers: [otlp, datadog/connector, prometheus]
-                processors: [memory_limiter, infraattributes, batch]
+                processors: [memory_limiter, transform, infraattributes, batch]
                 exporters: [debug, datadog]
               logs:
                 receivers: [otlp]
-                processors: [memory_limiter, infraattributes, batch]
+                processors: [memory_limiter, transform, infraattributes, batch]
                 exporters: [debug, datadog]


### PR DESCRIPTION
To enable new operation name mappings for OpenTelemetry in Datadog we need:

- Launch OTel Collector with the feature gate `datadog.EnableOperationAndResourceNameV2` (enabled by default in `otel-agent`)
- Explicitly map span names to the operation.name attribute: 
  ```yaml
      processors:
        transform:
          trace_statements:
            - context: span
              statements:
              - set(attributes["operation.name"], name)
  ```