### PR TITLE
Fix Universal Service Tagging in Orchestrator Explorer

### DIFF
--- a/otel-agent-operator/k8s/calendar/deployment.yaml
+++ b/otel-agent-operator/k8s/calendar/deployment.yaml
@@ -10,6 +10,9 @@ metadata:
     app.kubernetes.io/instance: calendar
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
+    tags.datadoghq.com/env: demo
+    tags.datadoghq.com/service: calendar
+    tags.datadoghq.com/version: "1.0.0"
 spec:
   replicas: 3
   selector:
@@ -21,6 +24,9 @@ spec:
       labels:
         app.kubernetes.io/name: calendar
         app.kubernetes.io/instance: calendar
+        tags.datadoghq.com/env: demo
+        tags.datadoghq.com/service: calendar
+        tags.datadoghq.com/version: "1.0.0"
     spec:
       securityContext:
         {}

--- a/otel-agent-operator/k8s/calendar/service.yaml
+++ b/otel-agent-operator/k8s/calendar/service.yaml
@@ -10,6 +10,9 @@ metadata:
     app.kubernetes.io/instance: calendar
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
+    tags.datadoghq.com/env: demo
+    tags.datadoghq.com/service: calendar
+    tags.datadoghq.com/version: "1.0.0"
 spec:
   type: ClusterIP
   ports:


### PR DESCRIPTION
Orchestrator (pod) explorer UST tags are extracted from the pod labels: https://docs.datadoghq.com/infrastructure/containers/orchestrator_explorer/\?tab\=datadogoperator\#extracted-tags

Setting UST tags via OTEL_RESOURCE_ATTRIBUTES (as described in https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging/\?tab\=kubernetes\#opentelemetry) is not enough; we have to configure pods with **full** Unified Service Tagging configuration by adding the labels:

```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  labels:
    tags.datadoghq.com/env: "<ENV>"
    tags.datadoghq.com/service: "<SERVICE>"
    tags.datadoghq.com/version: "<VERSION>"
...
template:
  metadata:
    labels:
      tags.datadoghq.com/env: "<ENV>"
      tags.datadoghq.com/service: "<SERVICE>"
      tags.datadoghq.com/version: "<VERSION>"
  containers:
  -  ...
     env:
          - name: DD_ENV
            valueFrom:
              fieldRef:
                fieldPath: metadata.labels['tags.datadoghq.com/env']
          - name: DD_SERVICE
            valueFrom:
              fieldRef:
                fieldPath: metadata.labels['tags.datadoghq.com/service']
          - name: DD_VERSION
            valueFrom:
              fieldRef:
                fieldPath: metadata.labels['tags.datadoghq.com/version']
```